### PR TITLE
Add streaming helpers 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,6 +15,7 @@ phpunit.xml export-ignore
 phpstan.neon export-ignore
 
 .gitignore export-ignore
+.php-version export-ignore
 .editorconfig export-ignore
 .gitattributes export-ignore
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,30 @@
 
 A PHP library for generating and streaming virtual ZIP archives on-the-fly without consuming disk space. Perfect for constraint environments where storage is limited.
 
+## Table of Contents
+
+- [Overview](#overview)
+- [Key Features](#key-features)
+- [Important Limitations](#important-limitations)
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+  - [Basic Usage](#basic-usage)
+  - [Advanced Reading](#advanced-reading)
+  - [Adding Files with Custom Names](#adding-files-with-custom-names)
+  - [Handling Duplicates](#handling-duplicates)
+  - [Stream to Output](#stream-to-output)
+- [Advanced Features](#advanced-features)
+  - [Custom Entry File Handlers](#custom-entry-file-handlers)
+  - [Seeking Behavior](#seeking-behavior)
+- [Configuration Options](#configuration-options)
+- [Architecture](#architecture)
+- [Examples](#examples)
+  - [Simple File Download Server](#simple-file-download-server)
+  - [Backup Logs Files](#backup-logs-files)
+  - [ZIP From Database BLOBs](#zip-from-database-blobs)
+- [License](#license)
+
 ## Overview
 
 **ZipStore** enables you to add files to a virtual ZIP store and then read from it as if it were a native file resource, using familiar `seek()` and `read()` operations. The library generates ZIP file components on-demand while reading file contents live, making it ideal for serving large file downloads with minimal memory and disk overhead.
@@ -237,7 +261,7 @@ header('Cache-Control: public, must-revalidate');
 $opened->passthru();
 ```
 
-### Backup Multiple Files
+### Backup Logs Files
 
 ```php
 $store = new Store();
@@ -252,7 +276,7 @@ $opened = $store->open();
 $opened->writeToStream($stream, resetOffset: true);
 ```
 
-### ZIP from Database BLOBs
+### ZIP From Database BLOBs
 
 ```php
 use ZipStore\Entry;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ZIP Store
+# ZIPStore
 
-A lightweight PHP library for creating and streaming virtual ZIP archives on-the-fly without consuming disk space. Perfect for constraint environments where storage is limited.
+A PHP library for generating and streaming virtual ZIP archives on-the-fly without consuming disk space. Perfect for constraint environments where storage is limited.
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ZIP Store
 
-A lightweight PHP library for creating and streaming virtual ZIP archives on-the-fly without consuming significant disk space. Perfect for constraint environments where storage is limited.
+A lightweight PHP library for creating and streaming virtual ZIP archives on-the-fly without consuming disk space. Perfect for constraint environments where storage is limited.
 
 ## Overview
 
@@ -127,9 +127,7 @@ header('Content-Type: application/zip');
 header('Content-Disposition: attachment; filename="archive.zip"');
 header('Content-Length: ' . $opened->getSize());
 
-while (!$opened->eof()) {
-    echo $opened->read();
-}
+$opened->passthru();
 ```
 
 ## Advanced Features
@@ -233,10 +231,7 @@ header('Content-Disposition: attachment; filename="download.zip"');
 header('Content-Length: ' . $opened->getSize());
 header('Cache-Control: public, must-revalidate');
 
-while (!$opened->eof()) {
-    echo $opened->read();
-    flush();
-}
+$opened->passthru();
 ```
 
 ### Backup Multiple Files
@@ -251,8 +246,7 @@ foreach (glob('/data/backups/*.log') as $logFile) {
 
 $opened = $store->open();
 
-while(!$opened->eof())
-    fwrite($stream, $opened->read());
+$opened->writeToStream($stream, resetOffset: true);
 ```
 
 ### ZIP from Database BLOBs
@@ -303,9 +297,9 @@ header('Content-Type: application/zip');
 header('Content-Disposition: attachment; filename="database-export.zip"');
 header('Content-Length: ' . $opened->getSize());
 
-while (!$opened->eof()) {
-    echo $opened->read();
-}
+
+// equivalent (current internal) of OpenedStore@passthru() 
+$opened->writeTo(path: "php://output", resetOffset: true);
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ $bytes = 1024 * 1024 * 4; // 4 MiB
 
 $openedStore->seek($offset);
 $buffer = $openedStore->read($bytes);
+
+// current offset after seek and read
+echo $openedStore->tell();  // 4194304 
 ```
 
 ### Advanced Reading

--- a/src/OpenedStore.php
+++ b/src/OpenedStore.php
@@ -169,6 +169,11 @@ class OpenedStore
         return 0;
     }
 
+    public function tell(): int|false
+    {
+        return $this->offset;
+    }
+
     public function writeTo(string $path, bool $resetOffset = true): void
     {
         $stream = \fopen($path, 'w');

--- a/src/OpenedStore.php
+++ b/src/OpenedStore.php
@@ -63,6 +63,11 @@ class OpenedStore
         return $this->size ??= $entriesSize + $cdSize + $eocdSize;
     }
 
+    public function passthru(): void
+    {
+        $this->writeTo('php://output', true);
+    }
+
     /**
      * read $bytes of the virtually packed zip file
      * from the @seek(ed) offset
@@ -162,6 +167,43 @@ class OpenedStore
         $this->readBytes = $offset;
 
         return 0;
+    }
+
+    public function writeTo(string $path, bool $resetOffset = true): void
+    {
+        $stream = \fopen($path, 'w');
+
+        if (! $stream) {
+            throw new \Exception("Failed to open {$path}");
+        }
+
+        try {
+            $this->writeToStream($stream, $resetOffset);
+        } finally {
+            \fclose($stream);
+        }
+    }
+
+    /**
+     * @param  resource  $stream
+     * @return void
+     */
+    public function writeToStream(mixed $stream, bool $resetOffset = false)
+    {
+        if ($resetOffset) {
+            $this->seek(0);
+        }
+
+        while (! $this->eof()) {
+            $buffer = $this->read(throw: true);
+            $written = \fwrite($stream, $buffer, $buffer->size);
+
+            if ($written !== $buffer->size) {
+                throw new \Exception('Failed to write buffer into stream');
+            }
+        }
+
+        \fflush($stream);
     }
 
     private function validateFilesize(): void

--- a/src/OpenedStore.php
+++ b/src/OpenedStore.php
@@ -20,7 +20,7 @@ class OpenedStore
 
     public EndOfCentralDirectory $eocdir;
 
-    private int $readBytes;
+    private int $offset;
 
     private int $size;
 
@@ -30,7 +30,7 @@ class OpenedStore
      */
     public function __construct(array $entries)
     {
-        $this->readBytes = 0;
+        $this->offset = 0;
         $this->entries = new EntryCollection($entries);
 
         $this->cdir = new CentralDirectory(
@@ -47,7 +47,7 @@ class OpenedStore
 
     public function eof(): bool
     {
-        return $this->getSize() === $this->readBytes;
+        return $this->getSize() === $this->offset;
     }
 
     public function getSize(): int
@@ -82,11 +82,11 @@ class OpenedStore
             $this->seek($offset);
         }
 
-        $offset = $this->readBytes;
+        $offset = $this->offset;
 
         /* fetch bytes */
         /* from entries if $offset < $entriesSize */
-        if ($this->readBytes < $this->entries->getSize()) {
+        if ($this->offset < $this->entries->getSize()) {
 
             foreach ($this->entries as $entry) {
                 /* skip if not in range */
@@ -140,7 +140,7 @@ class OpenedStore
         }
 
         /* adjust offset */
-        $this->readBytes += $buffer->size;
+        $this->offset += $buffer->size;
 
         return $buffer;
     }
@@ -151,7 +151,7 @@ class OpenedStore
     public function seek(int $offset, int $whence = SEEK_SET): int
     {
         $offset += match ($whence) {
-            SEEK_CUR => $this->readBytes,
+            SEEK_CUR => $this->offset,
             SEEK_END => $this->getSize(),
             default => 0,
         };
@@ -164,7 +164,7 @@ class OpenedStore
             $offset = $this->getSize();
         }
 
-        $this->readBytes = $offset;
+        $this->offset = $offset;
 
         return 0;
     }

--- a/src/Supports/StringBuffer.php
+++ b/src/Supports/StringBuffer.php
@@ -9,9 +9,9 @@ class StringBuffer implements \Stringable
     /** @var int<0,max> */
     public int $size = 0;
 
-    public function __construct(public readonly int $limit)
+    public function __construct(public readonly int $capacity)
     {
-        if ($limit < 0) {
+        if ($capacity < 0) {
             throw new \InvalidArgumentException('Negative size buffer not supported');
         }
     }
@@ -28,17 +28,17 @@ class StringBuffer implements \Stringable
 
     public function isFull(): bool
     {
-        return $this->limit === $this->size;
+        return $this->capacity === $this->size;
     }
 
     public function leftSize(): int
     {
-        return $this->limit - $this->size;
+        return $this->capacity - $this->size;
     }
 
     public function write(string $content): int
     {
-        $content = \substr($content, 0, $this->limit - $this->size);
+        $content = \substr($content, 0, $this->capacity - $this->size);
         $toWrite = \strlen($content);
 
         $this->size += $toWrite;

--- a/tests/Concerns/HasStoreTestUtilities.php
+++ b/tests/Concerns/HasStoreTestUtilities.php
@@ -161,21 +161,7 @@ trait HasStoreTestUtilities
         }
 
         try {
-            while (true) {
-                $buffer = $openedStore->read(throw: true);
-
-                if ($buffer->isEmpty()) {
-                    break;
-                }
-
-                $written = \fwrite($stream, $buffer, $buffer->size);
-
-                if ($written !== $buffer->size) {
-                    throw new \Exception('Failed to write buffer into archive file');
-                }
-            }
-
-            \fflush($stream);
+           $openedStore->writeToStream($stream, false) ;
         } finally {
             \fclose($stream);
         }

--- a/tests/PartialReadingAfterPostSerializationTest.php
+++ b/tests/PartialReadingAfterPostSerializationTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\TestCase;
 use SplFileInfo;
 use Tests\Concerns\HasFiles;
 use Tests\Concerns\HasStoreTestUtilities;
-use Tests\Exceptions\FileIntegrityException;
 use ZipStore\OpenedStore;
 use ZipStore\Store;
 
@@ -42,6 +41,8 @@ class PartialReadingAfterPostSerializationTest extends TestCase
     #[TestDox('Partial reading after deserialization')]
     public function handle(): void
     {
+        $this->expectNotToPerformAssertions();
+
         /** @var OpenedStore */
         $openedStore = \unserialize($this->serialiazedOpenedStore);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three streaming export methods: `passthru()` for direct output streaming, `writeTo()` for file destinations, and `writeToStream()` for custom stream handling.

* **Documentation**
  * Updated README with simplified code examples demonstrating the new streaming API.

* **Refactor**
  * StringBuffer constructor parameter renamed for clarity (limit → capacity).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->